### PR TITLE
ci: create a grafana distribution with greptimedb plugin on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: setup-node
@@ -46,3 +46,19 @@ jobs:
         with:
           files: |
             info8fcc-greptimedb-datasource.zip
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          file: docker/Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: |
+            greptime/grafana-greptimedb:11.2-greptime-${{  github.ref_name }}
+            greptime/grafana-greptimedb:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,5 @@
+FROM docker.io/grafana/grafana:11.2.5
+
+COPY info8fcc-greptimedb-datasource.zip /
+RUN unzip -d info8fcc-greptimedb-datasource.zip /var/lib/grafana/plugins/
+RUN rm /info8fcc-greptimedb-datasource.zip


### PR DESCRIPTION
add a `Dockerfile` that generate a grafana docker with greptimedb plugin preinstalled.