### PR TITLE
chore: add nix shell configuration to specify dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ greptime-ds
 greptime-ds-*.zip
 info8fcc-greptimedb-datasource
 info8fcc-greptimedb-datasource*.zip
+
+# direnv
+.direnv
+.envrc

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,21 @@
+let
+  nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-24.11";
+  pkgs = import nixpkgs { config = {}; overlays = []; };
+in
+
+pkgs.mkShell rec {
+  nativeBuildInputs = with pkgs; [
+    git
+    go
+    nodejs
+    zip
+    yarn
+    mage
+    podman
+  ];
+
+  buildInputs = with pkgs; [
+  ];
+
+  LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
+}


### PR DESCRIPTION
This allows us to declare what components we really need to build this tool.